### PR TITLE
expose_url_who_return_a_list_of_person_covered_by_a_fireStation

### DIFF
--- a/src/main/java/com/openClassroomsProject/SafetyNetAlerts/controller/FireStationController.java
+++ b/src/main/java/com/openClassroomsProject/SafetyNetAlerts/controller/FireStationController.java
@@ -3,6 +3,7 @@ package com.openClassroomsProject.SafetyNetAlerts.controller;
 import com.openClassroomsProject.SafetyNetAlerts.exception.CustomGenericException;
 import com.openClassroomsProject.SafetyNetAlerts.exception.ResourceNotFoundException;
 import com.openClassroomsProject.SafetyNetAlerts.model.FireStation;
+import com.openClassroomsProject.SafetyNetAlerts.model.PersonListCoveredByAFireStation;
 import com.openClassroomsProject.SafetyNetAlerts.service.IFireStationService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,6 +21,23 @@ public class FireStationController {
     @Autowired
     private IFireStationService fireStationService;
     private static final String CLASSPATH = "com.openClassroomsProject.SafetyNetAlerts.controller.FireStationController";
+
+    @GetMapping("/firestation")
+    public ResponseEntity<Optional<PersonListCoveredByAFireStation>> getPersonListCoveredByAFireStation(@RequestParam String fireStation) {
+        String functionPath = CLASSPATH + ".getPersonListCoveredByAFireStation";
+        log.info("Request received  in " + functionPath);
+        Optional<PersonListCoveredByAFireStation> requestContent;
+        try {
+            requestContent = fireStationService.getPersonListCoveredByAFireStation(fireStation);
+        } catch (Exception exception) {
+            throw new CustomGenericException(functionPath, exception);
+        }
+        if (requestContent.isEmpty()) {
+            throw new ResourceNotFoundException(functionPath, "Nothing found for this fireStation");
+        }
+        log.info("Request success in " + functionPath);
+        return new ResponseEntity<>(requestContent, HttpStatus.OK);
+    }
 
     @GetMapping("/phoneAlert")
     public ResponseEntity<ArrayList<String>> getPhoneNumbersPersonServedByAFireStation(@RequestParam String fireStation) {

--- a/src/main/java/com/openClassroomsProject/SafetyNetAlerts/model/PersonCoveredByAFireStation.java
+++ b/src/main/java/com/openClassroomsProject/SafetyNetAlerts/model/PersonCoveredByAFireStation.java
@@ -1,0 +1,11 @@
+package com.openClassroomsProject.SafetyNetAlerts.model;
+
+import lombok.Data;
+
+@Data
+public class PersonCoveredByAFireStation {
+    private String firstName;
+    private String lastName;
+    private String address;
+    private String phoneNumber;
+}

--- a/src/main/java/com/openClassroomsProject/SafetyNetAlerts/model/PersonListCoveredByAFireStation.java
+++ b/src/main/java/com/openClassroomsProject/SafetyNetAlerts/model/PersonListCoveredByAFireStation.java
@@ -1,0 +1,16 @@
+package com.openClassroomsProject.SafetyNetAlerts.model;
+
+import lombok.Data;
+import java.util.ArrayList;
+import java.util.HashMap;
+
+@Data
+public class PersonListCoveredByAFireStation {
+    private ArrayList<PersonCoveredByAFireStation> list;
+    private HashMap<String, String> numberOfAdultsAndChildren;
+
+    public PersonListCoveredByAFireStation(ArrayList<PersonCoveredByAFireStation> list, HashMap<String, String> numberOfAdultsAndChildren) {
+        this.list = list;
+        this.numberOfAdultsAndChildren = numberOfAdultsAndChildren;
+    }
+}

--- a/src/main/java/com/openClassroomsProject/SafetyNetAlerts/service/IFireStationService.java
+++ b/src/main/java/com/openClassroomsProject/SafetyNetAlerts/service/IFireStationService.java
@@ -1,6 +1,7 @@
 package com.openClassroomsProject.SafetyNetAlerts.service;
 
 import com.openClassroomsProject.SafetyNetAlerts.model.FireStation;
+import com.openClassroomsProject.SafetyNetAlerts.model.PersonListCoveredByAFireStation;
 import org.springframework.stereotype.Service;
 import java.util.ArrayList;
 import java.util.List;
@@ -20,4 +21,6 @@ public interface IFireStationService {
      Optional<FireStation> deleteMappingOfAnAddress(String address);
 
      ArrayList<String> getPhoneNumbersPersonServedByAFireStation(String fireStationNumber);
+
+     Optional<PersonListCoveredByAFireStation> getPersonListCoveredByAFireStation(String fireStationNumber);
 }

--- a/src/test/java/com/openClassroomsProject/SafetyNetAlerts/controller/FireStationControllerTest.java
+++ b/src/test/java/com/openClassroomsProject/SafetyNetAlerts/controller/FireStationControllerTest.java
@@ -5,6 +5,8 @@ import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import com.openClassroomsProject.SafetyNetAlerts.model.FireStation;
+import com.openClassroomsProject.SafetyNetAlerts.model.PersonCoveredByAFireStation;
+import com.openClassroomsProject.SafetyNetAlerts.model.PersonListCoveredByAFireStation;
 import com.openClassroomsProject.SafetyNetAlerts.service.IFireStationService;
 import com.openClassroomsProject.SafetyNetAlerts.service.JsonDataService;
 import org.junit.jupiter.api.Test;
@@ -17,6 +19,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Optional;
 
 @RunWith(SpringRunner.class)
@@ -30,9 +33,31 @@ public class FireStationControllerTest {
     private IFireStationService fireStationService;
 
     @Test
+    public void testGetPersonListCoveredByAFireStationAndResponseIsOk() throws Exception {
+        ArrayList<PersonCoveredByAFireStation> testList = new ArrayList<>();
+        HashMap<String, String> testMap = new HashMap<>();
+        PersonListCoveredByAFireStation testObject = new PersonListCoveredByAFireStation(testList, testMap);
+
+        when(fireStationService.getPersonListCoveredByAFireStation(any(String.class))).thenReturn(Optional.of(testObject));
+        mockMvc.perform(get("/firestation")
+                .contentType(MediaType.APPLICATION_JSON)
+                .param("fireStation", "0"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void testGetPersonListCoveredByAFireStationAndResponseIsNotFound() throws Exception {
+        when(fireStationService.getPersonListCoveredByAFireStation(any(String.class))).thenReturn(Optional.empty());
+        mockMvc.perform(get("/firestation")
+                .contentType(MediaType.APPLICATION_JSON)
+                .param("fireStation", "0"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
     public void testGetPhoneNumbersPersonServedByAFireStationAndResponseIsOk() throws Exception {
-        ArrayList<String> requestContent = new ArrayList<>(Arrays.asList("000-000-000", "999-999-999"));
-        when(fireStationService.getPhoneNumbersPersonServedByAFireStation(any(String.class))).thenReturn(requestContent);
+        ArrayList<String> testList = new ArrayList<>(Arrays.asList("000-000-000", "999-999-999"));
+        when(fireStationService.getPhoneNumbersPersonServedByAFireStation(any(String.class))).thenReturn(testList);
         mockMvc.perform(get("/phoneAlert")
                 .contentType(MediaType.APPLICATION_JSON)
                 .param("fireStation", "0"))


### PR DESCRIPTION
Expose the URL: http: // localhost: 8080 / firestation? stationNumber = <station_number>

This url should return a list of people covered by the corresponding fire station.
So if the station number = 1, it must return the inhabitants covered by station number 1. The list
must include the following specific information: first name, last name, address, telephone number. Furthermore,
it must provide a count of the number of adults and the number of children (anyone aged 18 or over
less) in the service area. 